### PR TITLE
Set messageid be undefined in qos > 0 or non-publish command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# aedes-packet&nbsp;&nbsp;[![Build Status](https://travis-ci.org/mcollina/aedes-packet.svg)](https://travis-ci.org/mcollina/aedes-packet)
+# aedes-packet
+[![Build Status](https://travis-ci.org/mcollina/aedes-packet.svg?branch=master)](https://travis-ci.org/mcollina/aedes-packet)&nbsp;[![Known Vulnerabilities](https://snyk.io/test/github/mcollina/aedes-packet/badge.svg)](https://snyk.io/test/github/mcollina/aedes-packet)&nbsp;[![Coverage Status](https://coveralls.io/repos/mcollina/aedes-packet/badge.svg?branch=master&service=github)](https://coveralls.io/github/mcollina/aedes-packet?branch=master)&nbsp;[![NPM version](https://img.shields.io/npm/v/aedes-packet.svg?style=flat)](https://www.npmjs.com/package/aedes-packet)&nbsp;[![NPM downloads](https://img.shields.io/npm/dm/aedes-packet.svg?style=flat)](https://www.npmjs.com/package/aedes-packet)
+
 
 Basic data structure for packets in [Aedes](http://npm.im/aedes), packaged up for perf and reusability between modules.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ documentation and usage.
 
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
 
+## Collaborators
+
+* [__Gnought__](https://github.com/gnought)
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -3,17 +3,10 @@
   "version": "2.0.0",
   "description": "Basic data structure for packets in Aedes ",
   "main": "packet.js",
-  "dependencies": {},
-  "devDependencies": {
-    "faucet": "0.0.1",
-    "nyc": "^14.1.1",
-    "pre-commit": "^1.2.2",
-    "standard": "^13.0.2",
-    "tape": "^4.11.0"
-  },
   "scripts": {
     "test": "standard && tape test.js | faucet",
-    "coverage": "nyc --reporter=lcov tape test.js"
+    "coverage": "nyc --reporter=lcov tape test.js",
+    "license-checker": "license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause'"
   },
   "pre-commit": [
     "test"
@@ -39,5 +32,14 @@
   "bugs": {
     "url": "https://github.com/mcollina/aedes-packet/issues"
   },
-  "homepage": "https://github.com/mcollina/aedes-packet#readme"
+  "homepage": "https://github.com/mcollina/aedes-packet#readme",
+  "dependencies": {},
+  "devDependencies": {
+    "faucet": "0.0.1",
+    "license-checker": "^25.0.1",
+    "nyc": "^14.1.1",
+    "pre-commit": "^1.2.2",
+    "standard": "^13.0.2",
+    "tape": "^4.11.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "description": "Basic data structure for packets in Aedes ",
   "main": "packet.js",
   "scripts": {
-    "test": "standard && tape test.js | faucet",
+    "lint": "standard --verbose | snazzy",
+    "test": "tape test.js | faucet",
     "coverage": "nyc --reporter=lcov tape test.js",
     "license-checker": "license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause'"
   },
   "pre-commit": [
+    "lint",
     "test"
   ],
   "repository": {
@@ -39,6 +41,7 @@
     "license-checker": "^25.0.1",
     "nyc": "^14.1.1",
     "pre-commit": "^1.2.2",
+    "snazzy": "^8.0.0",
     "standard": "^13.0.2",
     "tape": "^4.11.0"
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,12 @@
     "aedes"
   ],
   "author": "Matteo Collina <hello@matteocollina.com>",
+  "contributors": [
+    {
+      "name": "Gnought",
+      "url": "https://github.com/gnought"
+    }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mcollina/aedes-packet/issues"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "test": "standard && tape test.js | faucet",
     "coverage": "nyc --reporter=lcov tape test.js"
   },
+  "pre-commit": [
+    "test"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mcollina/aedes-packet.git"

--- a/packet.js
+++ b/packet.js
@@ -11,7 +11,9 @@ function Packet (original, broker) {
   // [MQTT-2.3.1-5]
   if (this.qos > 0 || this.cmd !== 'publish') {
     //  [MQTT-2.3.1-1]
-    this.messageId = 1
+    // This is packet identifier uniquely identifies a message as it flows between
+    // client and broker. It is only relevant for QoS levels greater than 0
+    this.messageId = undefined
   }
 }
 

--- a/test.js
+++ b/test.js
@@ -12,7 +12,7 @@ test('Packet defaults - PUBLISH, QoS 0', function (t) {
   t.deepEqual(instance.payload, Buffer.alloc(0))
   t.equal(instance.qos, 0)
   t.equal(instance.retain, false)
-  t.equal(instance.messageId, undefined)
+  t.notOk(Object.prototype.hasOwnProperty.call(instance, 'messageId'))
   t.end()
 })
 
@@ -25,7 +25,8 @@ test('Packet defaults - PUBREL, QoS 0', function (t) {
   t.deepEqual(instance.payload, Buffer.alloc(0))
   t.equal(instance.qos, 0)
   t.equal(instance.retain, false)
-  t.equal(instance.messageId, 1)
+  t.ok(Object.prototype.hasOwnProperty.call(instance, 'messageId'))
+  t.equal(instance.messageId, undefined)
   t.end()
 })
 
@@ -38,7 +39,8 @@ test('Packet defaults - PUBLISH, QoS 1', function (t) {
   t.deepEqual(instance.payload, Buffer.alloc(0))
   t.equal(instance.qos, 1)
   t.equal(instance.retain, false)
-  t.equal(instance.messageId, 1)
+  t.ok(Object.prototype.hasOwnProperty.call(instance, 'messageId'))
+  t.equal(instance.messageId, undefined)
   t.end()
 })
 
@@ -61,10 +63,12 @@ test('Packet copies over most data', function (t) {
     topic: 'hello',
     payload: 'world',
     qos: 2,
-    retain: true,
-    messageId: 1 // this is different
+    retain: true
   }
 
+  t.ok(Object.prototype.hasOwnProperty.call(instance, 'messageId'))
+  t.equal(instance.messageId, undefined)
+  delete instance.messageId
   t.deepEqual(instance, expected)
   t.end()
 })
@@ -90,10 +94,12 @@ test('Packet fills in broker data', function (t) {
     topic: 'hello',
     payload: 'world',
     qos: 2,
-    retain: true,
-    messageId: 1 // this is different
+    retain: true
   }
 
+  t.ok(Object.prototype.hasOwnProperty.call(instance, 'messageId'))
+  t.equal(instance.messageId, undefined)
+  delete instance.messageId
   t.deepEqual(instance, expected)
   t.end()
 })


### PR DESCRIPTION
This is for issue https://github.com/mcollina/aedes-packet/issues/4

Mainly we need to let `QoSPacket` in aedes could be assigned a correct messageId in `deliverQoS` function
https://github.com/mcollina/aedes/blob/master/lib/client.js#L118
https://github.com/mcollina/aedes/blob/master/lib/qos-packet.js#L11
